### PR TITLE
fix issue perl version warning for any task (from EngineFactory invocation) when perl is not installed on the machine, retrieve correct version of perl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
         exclude module: 'hamcrest-core'
     }
     testCompile 'org.mockito:mockito-all:1.10.19'
+    testCompile 'org.powermock:powermock-mockito-release-full:1.6.2'
 }
 
 // Must be called after dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -63,13 +63,13 @@ release {
 dependencies {
     compile 'org.projectlombok:lombok:1.16.6'
     compile 'log4j:log4j:1.2.17'
+    compile 'com.google.guava:guava:19.0'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.1'
     testCompile('junit:junit:4.12') {
         exclude module: 'hamcrest'
         exclude module: 'hamcrest-core'
     }
     testCompile 'org.mockito:mockito-all:1.10.19'
-    testCompile 'org.powermock:powermock-mockito-release-full:1.6.2'
 }
 
 // Must be called after dependencies

--- a/src/main/java/jsr223/perl/PerlScriptEngineFactory.java
+++ b/src/main/java/jsr223/perl/PerlScriptEngineFactory.java
@@ -25,50 +25,38 @@
  */
 package jsr223.perl;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
 
 import jsr223.perl.utils.PerlVersionGetter;
-import processbuilder.PerlSingletonPerlProcessBuilderFactory;
-import processbuilder.utils.PerlProcessBuilderUtilities;
 
 
 public class PerlScriptEngineFactory implements ScriptEngineFactory {
-    private final Map<String, Object> parameters = new HashMap<>();
-
-    private static PerlProcessBuilderUtilities processBuilderUtilities = new PerlProcessBuilderUtilities();
-
-    private static PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilities);
+    private static final Map<String, Object> parameters = new HashMap();
 
     // Script engine parameters
     private static final String NAME = "perl";
 
     private static final String ENGINE = NAME;
 
-    private static final String PERL_VERSION = perlVersionGetter.getPerlVersion(PerlSingletonPerlProcessBuilderFactory.getInstance());
-
-    private static final String ENGINE_VERSION = (PERL_VERSION.equals("") ? "0.1.0" : PERL_VERSION);
+    private static final String PERL_ENGINE_VERSION = new PerlVersionGetter().getPerlVersion();
 
     private static final String LANGUAGE = "perl";
 
-    public PerlScriptEngineFactory() {
+    private static final String LANGUAGE_VERSION = PERL_ENGINE_VERSION;
+
+    static {
         parameters.put(ScriptEngine.NAME, NAME);
-        parameters.put(ScriptEngine.ENGINE_VERSION, ENGINE_VERSION);
-        parameters.put(ScriptEngine.LANGUAGE, LANGUAGE);
         parameters.put(ScriptEngine.ENGINE, ENGINE);
-    }
-
-    public PerlScriptEngineFactory(PerlProcessBuilderUtilities processBuilderUtilities,
-            PerlVersionGetter perlVersionGetter) {
-        this();
-        if (processBuilderUtilities == null || perlVersionGetter == null) {
-            throw new NullPointerException("processBuilderUtilities and perlVersionGetter must not be null");
-        }
-        this.processBuilderUtilities = processBuilderUtilities;
-        this.perlVersionGetter = perlVersionGetter;
-
+        parameters.put(ScriptEngine.ENGINE_VERSION, PERL_ENGINE_VERSION);
+        parameters.put(ScriptEngine.LANGUAGE, LANGUAGE);
+        parameters.put(ScriptEngine.LANGUAGE_VERSION, LANGUAGE_VERSION);
     }
 
     @Override
@@ -103,7 +91,7 @@ public class PerlScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public String getLanguageVersion() {
-        return perlVersionGetter.getPerlVersion(PerlSingletonPerlProcessBuilderFactory.getInstance());
+        return (String) parameters.get(ScriptEngine.LANGUAGE_VERSION);
     }
 
     @Override

--- a/src/main/java/jsr223/perl/PerlScriptEngineFactory.java
+++ b/src/main/java/jsr223/perl/PerlScriptEngineFactory.java
@@ -27,46 +27,38 @@ package jsr223.perl;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineFactory;
+
+import com.google.common.collect.ImmutableMap;
 
 import jsr223.perl.utils.PerlVersionGetter;
 
 
 public class PerlScriptEngineFactory implements ScriptEngineFactory {
-    private static final Map<String, Object> parameters = new HashMap();
+    static final ImmutableMap<String, Object> PARAMETERS;
 
-    // Script engine parameters
-    private static final String NAME = "perl";
-
-    private static final String ENGINE = NAME;
-
-    private static final String PERL_ENGINE_VERSION = new PerlVersionGetter().getPerlVersion();
-
-    private static final String LANGUAGE = "perl";
-
-    private static final String LANGUAGE_VERSION = PERL_ENGINE_VERSION;
-
+    // Script engine PARAMETERS
     static {
-        parameters.put(ScriptEngine.NAME, NAME);
-        parameters.put(ScriptEngine.ENGINE, ENGINE);
-        parameters.put(ScriptEngine.ENGINE_VERSION, PERL_ENGINE_VERSION);
-        parameters.put(ScriptEngine.LANGUAGE, LANGUAGE);
-        parameters.put(ScriptEngine.LANGUAGE_VERSION, LANGUAGE_VERSION);
+        String perlEngineVersion = new PerlVersionGetter().getPerlVersion();
+        PARAMETERS = new ImmutableMap.Builder<String, Object>().put(ScriptEngine.NAME, "perl")
+                                                               .put(ScriptEngine.ENGINE, "perl")
+                                                               .put(ScriptEngine.ENGINE_VERSION, perlEngineVersion)
+                                                               .put(ScriptEngine.LANGUAGE, "perl")
+                                                               .put(ScriptEngine.LANGUAGE_VERSION, perlEngineVersion)
+                                                               .build();
     }
 
     @Override
     public String getEngineName() {
-        return (String) parameters.get(ScriptEngine.NAME);
+        return (String) PARAMETERS.get(ScriptEngine.NAME);
     }
 
     @Override
     public String getEngineVersion() {
-        return (String) parameters.get(ScriptEngine.ENGINE_VERSION);
+        return (String) PARAMETERS.get(ScriptEngine.ENGINE_VERSION);
     }
 
     @Override
@@ -81,22 +73,22 @@ public class PerlScriptEngineFactory implements ScriptEngineFactory {
 
     @Override
     public List<String> getNames() {
-        return Arrays.asList(ENGINE, "perl", "Perl");
+        return Arrays.asList((String) PARAMETERS.get(ScriptEngine.ENGINE), "perl", "Perl");
     }
 
     @Override
     public String getLanguageName() {
-        return (String) parameters.get(ScriptEngine.LANGUAGE);
+        return (String) PARAMETERS.get(ScriptEngine.LANGUAGE);
     }
 
     @Override
     public String getLanguageVersion() {
-        return (String) parameters.get(ScriptEngine.LANGUAGE_VERSION);
+        return (String) PARAMETERS.get(ScriptEngine.LANGUAGE_VERSION);
     }
 
     @Override
     public Object getParameter(String key) {
-        return parameters.get(key);
+        return PARAMETERS.get(key);
     }
 
     @Override

--- a/src/main/java/jsr223/perl/utils/PerlVersionGetter.java
+++ b/src/main/java/jsr223/perl/utils/PerlVersionGetter.java
@@ -82,6 +82,14 @@ public class PerlVersionGetter {
             // Extract output
             result = commandOutput.toString();
         } catch (Exception e) {
+            // The exception is ignored as in case of any error the PERL_VERSION_IF_NOT_INSTALLED string should be return as result
+            // The error is not logged because of the case when the perl is not installed on machine.
+            // In this case the logging error will be included in an output of any task executing in scheduler, because this method is used by PerlScriptEngineFactory.
+            // And via PerlScriptEngineFactory the getPerlVersion() is used indirectly for every starting task
+        } finally {
+            if (perlFile != null) {
+                perlFile.delete();
+            }
         }
         return result;
     }

--- a/src/main/java/jsr223/perl/utils/PerlVersionGetter.java
+++ b/src/main/java/jsr223/perl/utils/PerlVersionGetter.java
@@ -25,44 +25,55 @@
  */
 package jsr223.perl.utils;
 
-import java.io.IOException;
+import java.io.File;
 import java.io.StringWriter;
 
 import jsr223.perl.PerlCommandCreator;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
+import jsr223.perl.file.write.PerlScriptFileWriter;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import processbuilder.PerlProcessBuilderFactory;
+import processbuilder.PerlSingletonPerlProcessBuilderFactory;
 import processbuilder.utils.PerlProcessBuilderUtilities;
 
 
 @Log4j
-@RequiredArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor
 public class PerlVersionGetter {
 
-    @NonNull
-    private PerlProcessBuilderUtilities processBuilderUtilities;
+    public static final String PERL_VERSION_IF_NOT_INSTALLED = "Could not determine version";
+
+    private static final String PERL_VERSION_COMMAND = "print $];"; // this command is needed to retrieve only specific string with perl version
+
+    private PerlProcessBuilderUtilities processBuilderUtilities = new PerlProcessBuilderUtilities();;
+
+    private PerlProcessBuilderFactory factory = PerlSingletonPerlProcessBuilderFactory.getInstance();
 
     /**
      * Retrieves the Perl version.
      *
-     * @return The currently installed version return by the perl command or an empty string
+     * @return The currently installed version return by the perl command or an string that
      * the version could not be determined.
      */
-    public String getPerlVersion(PerlProcessBuilderFactory factory) {
-        if (factory == null) {
-            return "";
-        }
+    public String getPerlVersion() {
+        String result = PERL_VERSION_IF_NOT_INSTALLED; // Default error string for result if version recovery fails
 
-        String result = ""; // Empty string for empty result if version recovery fails
-
-        ProcessBuilder processBuilder = factory.getProcessBuilder(PerlCommandCreator.getPerlCommand(), "-v");
-
+        PerlCommandCreator perlCommandCreator = new PerlCommandCreator();
+        PerlScriptFileWriter perlScriptFileWriter = new PerlScriptFileWriter();
+        File perlFile = null;
         try {
+            perlFile = perlScriptFileWriter.forceFileToDisk(PERL_VERSION_COMMAND);
+
+            String[] perlCommand = perlCommandCreator.createPerlExecutionCommand(perlFile);
+
+            ProcessBuilder processBuilder = factory.getProcessBuilder(perlCommand);
             Process process = processBuilder.start();
 
             // Attach stream to std output of process
             StringWriter commandOutput = new StringWriter();
+
             processBuilderUtilities.attachStreamsToProcess(process, commandOutput, null, null);
 
             // Wait for process to exit
@@ -70,8 +81,7 @@ public class PerlVersionGetter {
 
             // Extract output
             result = commandOutput.toString();
-        } catch (IOException | InterruptedException | IndexOutOfBoundsException e) {
-            log.warn("Failed to retrieve perl version.", e);
+        } catch (Exception e) {
         }
         return result;
     }

--- a/src/test/java/jsr223/perl/PerlScriptEngineFactoryTest.java
+++ b/src/test/java/jsr223/perl/PerlScriptEngineFactoryTest.java
@@ -26,140 +26,77 @@
 package jsr223.perl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 import javax.script.ScriptEngine;
 
 import org.junit.Test;
 
-import jsr223.perl.utils.PerlVersionGetter;
-import processbuilder.PerlProcessBuilderFactory;
-import processbuilder.utils.PerlProcessBuilderUtilities;
-
 
 public class PerlScriptEngineFactoryTest {
-
-    @Test(expected = NullPointerException.class)
-    public void testThatVersionGetterCannotBeNull() {
-        new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(), null);
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testThatProcessBuilderCannotBeNull() {
-        new PerlScriptEngineFactory(null, new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-    }
-
-    @Test(expected = NullPointerException.class)
-    public void testThatVersionGetterAndProcessBuilderCannotBeNull() {
-        new PerlScriptEngineFactory(null, null);
-    }
+    PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory();
 
     @Test
     public void testThatPerlVersionGetterIsUsed() {
-        PerlVersionGetter perlVersionGetterMock = mock(PerlVersionGetter.class);
-        String testVersion = "someVersion 44";
-        when(perlVersionGetterMock.getPerlVersion(any(PerlProcessBuilderFactory.class))).thenReturn(testVersion);
-
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      perlVersionGetterMock);
-
-        assertThat(perlScriptEngineFactory.getLanguageVersion(), is(testVersion));
-    }
-
-    @Test
-    public void testThatDefaultEngineVersionIsReturned() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory();
-        assertThat(perlScriptEngineFactory.getEngineVersion(), is("0.1.0"));
+        String version = perlScriptEngineFactory.getLanguageVersion();
+        assertThat(version, notNullValue());
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsScriptEngine() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getScriptEngine() instanceof PerlScriptEngine, is(true));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsNonNullParameterName() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.NAME), is(notNullValue()));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsNonNullParameterEngineVersion() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.ENGINE_VERSION), is(notNullValue()));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsNonNullParameterLanguage() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.LANGUAGE), is(notNullValue()));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsNonNullParameterEngine() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.ENGINE), is(notNullValue()));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsNonNullLanguageName() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getEngineName(), is(notNullValue()));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryNamesContainsPerl() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getNames(), hasItem(containsString("perl")));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryMimesTypesContainsPerlFile() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getMimeTypes(), hasItem(containsString("pl")));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryExtensionContainsPerlFile() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getExtensions(), hasItem(containsString("pl")));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryEngineVersionIsNonNull() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getEngineVersion(), is(notNullValue()));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryLanguageIsNonNull() {
-        PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory(new PerlProcessBuilderUtilities(),
-                                                                                      new PerlVersionGetter(new PerlProcessBuilderUtilities()));
-
         assertThat(perlScriptEngineFactory.getLanguageName(), is(notNullValue()));
     }
 }

--- a/src/test/java/jsr223/perl/PerlScriptEngineFactoryTest.java
+++ b/src/test/java/jsr223/perl/PerlScriptEngineFactoryTest.java
@@ -29,7 +29,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 import javax.script.ScriptEngine;
 
@@ -37,12 +36,12 @@ import org.junit.Test;
 
 
 public class PerlScriptEngineFactoryTest {
-    PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory();
+    private PerlScriptEngineFactory perlScriptEngineFactory = new PerlScriptEngineFactory();
 
     @Test
-    public void testThatPerlVersionGetterIsUsed() {
-        String version = perlScriptEngineFactory.getLanguageVersion();
-        assertThat(version, notNullValue());
+    public void testGetLanguageVersion() {
+        assertThat(perlScriptEngineFactory.getLanguageVersion(),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.LANGUAGE_VERSION)));
     }
 
     @Test
@@ -51,28 +50,33 @@ public class PerlScriptEngineFactoryTest {
     }
 
     @Test
-    public void testThatPerlScriptEngineFactoryReturnsNonNullParameterName() {
-        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.NAME), is(notNullValue()));
+    public void testThatPerlScriptEngineFactoryReturnsParameterName() {
+        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.NAME),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.NAME)));
     }
 
     @Test
-    public void testThatPerlScriptEngineFactoryReturnsNonNullParameterEngineVersion() {
-        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.ENGINE_VERSION), is(notNullValue()));
+    public void testThatPerlScriptEngineFactoryReturnsParameterEngineVersion() {
+        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.ENGINE_VERSION),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.ENGINE_VERSION)));
     }
 
     @Test
-    public void testThatPerlScriptEngineFactoryReturnsNonNullParameterLanguage() {
-        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.LANGUAGE), is(notNullValue()));
+    public void testThatPerlScriptEngineFactoryReturnsParameterLanguage() {
+        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.LANGUAGE),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.LANGUAGE)));
     }
 
     @Test
-    public void testThatPerlScriptEngineFactoryReturnsNonNullParameterEngine() {
-        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.ENGINE), is(notNullValue()));
+    public void testThatPerlScriptEngineFactoryReturnsParameterEngine() {
+        assertThat(perlScriptEngineFactory.getParameter(ScriptEngine.ENGINE),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.ENGINE)));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryReturnsNonNullLanguageName() {
-        assertThat(perlScriptEngineFactory.getEngineName(), is(notNullValue()));
+        assertThat(perlScriptEngineFactory.getEngineName(),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.ENGINE)));
     }
 
     @Test
@@ -92,11 +96,13 @@ public class PerlScriptEngineFactoryTest {
 
     @Test
     public void testThatPerlScriptEngineFactoryEngineVersionIsNonNull() {
-        assertThat(perlScriptEngineFactory.getEngineVersion(), is(notNullValue()));
+        assertThat(perlScriptEngineFactory.getEngineVersion(),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.ENGINE_VERSION)));
     }
 
     @Test
     public void testThatPerlScriptEngineFactoryLanguageIsNonNull() {
-        assertThat(perlScriptEngineFactory.getLanguageName(), is(notNullValue()));
+        assertThat(perlScriptEngineFactory.getLanguageName(),
+                   is(perlScriptEngineFactory.PARAMETERS.get(ScriptEngine.LANGUAGE)));
     }
 }

--- a/src/test/java/jsr223/perl/utils/PerlVersionGetterTest.java
+++ b/src/test/java/jsr223/perl/utils/PerlVersionGetterTest.java
@@ -27,6 +27,7 @@ package jsr223.perl.utils;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -47,28 +48,36 @@ import processbuilder.utils.PerlProcessBuilderUtilities;
 public class PerlVersionGetterTest {
 
     @Test
-    public void getPerlVersionCallsProcessBuilderFactory() throws Exception {
+    public void getPerlVersionCallsProcessBuilderFactory() {
         PerlProcessBuilderFactory factory = mock(PerlProcessBuilderFactory.class);
         PerlProcessBuilderUtilities processBuilderUtilitiesMock = spy(PerlProcessBuilderUtilities.class);
 
         when(factory.getProcessBuilder(Matchers.<String[]> anyVararg())).thenReturn(new ProcessBuilder(""));
 
-        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock);
-        perlVersionGetter.getPerlVersion(factory);
+        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock, factory);
+        perlVersionGetter.getPerlVersion();
 
         verify(factory).getProcessBuilder(Matchers.<String[]> anyVararg());
     }
 
     @Test
-    public void getPerlVersionInvalidCommandReturnsEmptyString() throws Exception {
+    public void getPerlVersionForCommandBuilder() {
+        PerlVersionGetter perlVersionGetter = new PerlVersionGetter();
+        String result = perlVersionGetter.getPerlVersion();
+
+        assertThat(result, is(notNullValue()));
+    }
+
+    @Test
+    public void getPerlVersionInvalidCommandReturnsDefaultString() throws Exception {
         PerlProcessBuilderFactory factory = mock(PerlProcessBuilderFactory.class);
         PerlProcessBuilderUtilities processBuilderUtilitiesMock = spy(PerlProcessBuilderUtilities.class);
 
         when(factory.getProcessBuilder(Matchers.<String[]> anyVararg())).thenReturn(new ProcessBuilder("...."));
 
-        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock);
+        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock, factory);
 
-        assertThat(perlVersionGetter.getPerlVersion(factory), is(""));
+        assertThat(perlVersionGetter.getPerlVersion(), is(PerlVersionGetter.PERL_VERSION_IF_NOT_INSTALLED));
     }
 
     @Test
@@ -82,9 +91,9 @@ public class PerlVersionGetterTest {
                                                                                                            "/C",
                                                                                                            "dir"));
 
-        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock);
+        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock, factoryMock);
 
-        perlVersionGetter.getPerlVersion(factoryMock);
+        perlVersionGetter.getPerlVersion();
 
         verify(processBuilderUtilitiesMock).attachStreamsToProcess(any(Process.class),
                                                                    any(Writer.class),
@@ -101,8 +110,8 @@ public class PerlVersionGetterTest {
 
         when(factoryMock.getProcessBuilder(Matchers.<String[]> anyVararg())).thenReturn(new ProcessBuilder("ls"));
 
-        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock);
-        perlVersionGetter.getPerlVersion(factoryMock);
+        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(processBuilderUtilitiesMock, factoryMock);
+        perlVersionGetter.getPerlVersion();
 
         verify(processBuilderUtilitiesMock).attachStreamsToProcess(any(Process.class),
                                                                    any(Writer.class),
@@ -111,9 +120,9 @@ public class PerlVersionGetterTest {
     }
 
     @Test
-    public void getPerlVersionNullFactoryReturnsEmptyString() throws Exception {
-        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(new PerlProcessBuilderUtilities());
+    public void getPerlVersionNullFactoryReturnsDefaultErrorString() throws Exception {
+        PerlVersionGetter perlVersionGetter = new PerlVersionGetter(new PerlProcessBuilderUtilities(), null);
 
-        assertThat(perlVersionGetter.getPerlVersion(null), is(""));
+        assertThat(perlVersionGetter.getPerlVersion(), is(PerlVersionGetter.PERL_VERSION_IF_NOT_INSTALLED));
     }
 }


### PR DESCRIPTION
This patch resolves ow2-proactive/jsr223-perl#6