### PR TITLE
Enable ProcessTreeKiller in native script engines

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,14 @@ install {
 defaultTasks 'jar'
 
 repositories {
-    mavenCentral()
+    if (project.hasProperty('local')) {
+        mavenLocal()
+    }
+    jcenter()
+    maven {
+        url "https://plugins.gradle.org/m2/"
+    }
+    maven { url 'http://repository.activeeon.com/content/groups/proactive/'}
 }
 
 buildscript {
@@ -49,6 +56,18 @@ buildscript {
     }
 }
 
+configurations {
+    provided
+}
+
+sourceSets {
+    main {
+        main.compileClasspath += configurations.provided
+        test.compileClasspath += configurations.provided
+        test.runtimeClasspath += configurations.provided
+    }
+}
+
 apply from: "$rootDir/gradle/ext/coding-format.gradle"
 
 // Configure the release process plugin
@@ -64,6 +83,7 @@ dependencies {
     compile 'org.projectlombok:lombok:1.16.6'
     compile 'log4j:log4j:1.2.17'
     compile 'com.google.guava:guava:19.0'
+    provided 'org.ow2.proactive:scheduler-api:+'
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.1'
     testCompile('junit:junit:4.12') {
         exclude module: 'hamcrest'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 # Another version property is in PerlScriptEngineFactory!!!
-version=0.1.0
+version=0.1.1
 


### PR DESCRIPTION
  - a cookie is generated based on a job and task ids if available.
  - ProcessTreeKiller is run when the script is terminated or aborted
  - reference scheduler-api classes
  - increase version